### PR TITLE
Add CUDA support via Docker Compose with 1-bit llama.cpp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+.git
+.worktree
+__pycache__
+*.pyc
+.artifacts

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+.git
+.worktree
+__pycache__
+*.pyc
+.artifacts
+docker

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,52 @@
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    cmake \
+    build-essential \
+    git \
+    curl \
+    libsndfile1 \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    python3.12 \
+    python3.12-dev \
+    python3.12-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.12 as default
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+
+# Install pip
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
+
+WORKDIR /app
+
+# Install PyTorch with CUDA first (large layer, cached separately)
+RUN pip install --no-cache-dir \
+    torch torchaudio --index-url https://download.pytorch.org/whl/cu128
+
+# Install remaining dependencies (no llama-cpp-python needed — LLM runs as separate server)
+COPY requirements-cuda.txt .
+RUN pip install --no-cache-dir -r requirements-cuda.txt
+
+# Install openai client for talking to llama-server
+RUN pip install --no-cache-dir openai
+
+# Copy application code
+COPY webui_chat.py .
+COPY irodori_tts/ ./irodori_tts/
+COPY configs/ ./configs/
+
+# Gradio listens on 0.0.0.0 inside container
+ENV GRADIO_SERVER_NAME=0.0.0.0
+
+EXPOSE 7860
+
+CMD ["python", "webui_chat.py"]

--- a/docker/Dockerfile.llm
+++ b/docker/Dockerfile.llm
@@ -1,0 +1,46 @@
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04 AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake build-essential git curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build PrismML fork of llama.cpp with CUDA (1-bit Q1_0_g128 kernel support)
+RUN git clone --branch prism --depth 1 https://github.com/PrismML-Eng/llama.cpp /tmp/llama.cpp \
+    && cd /tmp/llama.cpp \
+    && ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && cmake -B build -DGGML_CUDA=ON \
+    && LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH \
+       cmake --build build -j$(nproc) \
+    && rm /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+# Runtime stage
+FROM nvidia/cuda:12.8.0-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl python3 python3-pip libgomp1 \
+    && pip install --no-cache-dir huggingface-hub \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /tmp/llama.cpp/build/bin/llama-server /usr/local/bin/llama-server
+COPY --from=build /tmp/llama.cpp/build/bin/lib*.so* /usr/local/lib/
+
+RUN ldconfig
+
+# Download model script
+RUN echo '#!/bin/bash\n\
+MODEL_PATH="/models/Bonsai-8B.gguf"\n\
+if [ ! -f "$MODEL_PATH" ]; then\n\
+    echo "[llm] Downloading Bonsai-8B 1-bit GGUF..."\n\
+    python3 -c "\n\
+from huggingface_hub import hf_hub_download\n\
+hf_hub_download(repo_id=\"prism-ml/Bonsai-8B-gguf\", filename=\"Bonsai-8B.gguf\", local_dir=\"/models\")\n\
+"\n\
+    echo "[llm] Download complete!"\n\
+fi\n\
+exec llama-server "$@"\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/entrypoint.sh", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  llm:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.llm
+    command:
+      - "--model"
+      - "/models/Bonsai-8B.gguf"
+      - "--n-gpu-layers"
+      - "-1"
+      - "--ctx-size"
+      - "2048"
+      - "--chat-template"
+      - "chatml"
+    volumes:
+      - hf-cache:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    restart: unless-stopped
+
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cuda
+    ports:
+      - "7861:7860"
+    environment:
+      - LLM_API_BASE=http://llm:8080
+    volumes:
+      - hf-cache:/root/.cache/huggingface
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    depends_on:
+      llm:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  hf-cache:

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,24 @@
+# CUDA environment dependencies for irodori-bonsai
+# PyTorch with CUDA is installed separately in Dockerfile
+
+# LLM runs as separate llama.cpp server (no Python binding needed)
+
+# TTS (Irodori-TTS)
+dacvae @ git+https://github.com/facebookresearch/dacvae
+soundfile
+peft
+huggingface-hub
+safetensors
+transformers
+sentencepiece
+pyyaml
+tqdm
+numba
+llvmlite
+
+# WebUI
+gradio
+
+# Audio
+sounddevice
+numpy

--- a/webui_chat.py
+++ b/webui_chat.py
@@ -19,33 +19,59 @@ import torch
 _llm_model = None
 _llm_tokenizer = None
 _llm_history: list[dict] = []
+_llm_backend: str = ""  # "mlx" or "llama_cpp"
 
 SYSTEM_PROMPT = "あなたは「みどり」という名前の親切で明るいAIアシスタントです。日本語で短く自然に会話してください。長くても3文以内で答えてください。絵文字は使わないでください。"
 
 DEFAULT_CAPTION = "落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。"
 
-
 def load_llm():
-    global _llm_model, _llm_tokenizer, _llm_history
+    global _llm_model, _llm_tokenizer, _llm_history, _llm_backend
     if _llm_model is not None:
         return
-    from mlx_lm import load
-    print("[llm] Loading Bonsai-8B 1-bit...")
-    _llm_model, _llm_tokenizer = load("prism-ml/Bonsai-8B-mlx-1bit")
+
+    llm_api_base = os.environ.get("LLM_API_BASE")
+    if llm_api_base:
+        from openai import OpenAI
+
+        print(f"[llm] Using llama.cpp server at {llm_api_base}...")
+        _llm_model = OpenAI(base_url=f"{llm_api_base}/v1", api_key="no-key")
+        _llm_tokenizer = None
+        _llm_backend = "llama_server"
+    else:
+        from mlx_lm import load
+
+        print("[llm] Loading Bonsai-8B 1-bit via MLX...")
+        _llm_model, _llm_tokenizer = load("prism-ml/Bonsai-8B-mlx-1bit")
+        _llm_backend = "mlx"
+
     _llm_history = [{"role": "system", "content": SYSTEM_PROMPT}]
-    print("[llm] Bonsai-8B loaded!")
+    print(f"[llm] Bonsai-8B loaded! (backend={_llm_backend})")
 
 
 def llm_respond(message: str, history: list[dict]) -> str:
-    from mlx_lm import generate
     global _llm_history
 
     _llm_history.append({"role": "user", "content": message})
-    prompt = _llm_tokenizer.apply_chat_template(
-        _llm_history, tokenize=False, add_generation_prompt=True
-    )
-    response = generate(_llm_model, _llm_tokenizer, prompt=prompt, max_tokens=256)
-    clean = re.sub(r"<think>.*?</think>\s*", "", response, flags=re.DOTALL).strip()
+
+    if _llm_backend == "llama_server":
+        result = _llm_model.chat.completions.create(
+            model="bonsai-8b",
+            messages=_llm_history,
+            max_tokens=256,
+        )
+        msg = result.choices[0].message
+        response = msg.content or getattr(msg, "reasoning_content", "") or ""
+    else:
+        from mlx_lm import generate
+
+        prompt = _llm_tokenizer.apply_chat_template(
+            _llm_history, tokenize=False, add_generation_prompt=True
+        )
+        response = generate(_llm_model, _llm_tokenizer, prompt=prompt, max_tokens=256)
+
+    clean = re.sub(r"<think>.*?</think>\s*", "", response, flags=re.DOTALL)
+    clean = re.sub(r"</?think>", "", clean).strip()
     _llm_history.append({"role": "assistant", "content": clean})
     return clean
 
@@ -127,7 +153,8 @@ def build_ui():
     print("[ui] All models loaded!")
 
     with gr.Blocks(title="Midori Chat - Bonsai + Irodori-TTS") as demo:
-        gr.Markdown("# Midori Chat\nBonsai-8B (1-bit MLX) + Irodori-TTS VoiceDesign")
+        backend_label = "llama.cpp 1-bit CUDA" if _llm_backend == "llama_server" else "1-bit MLX"
+        gr.Markdown(f"# Midori Chat\nBonsai-8B (1-bit {backend_label}) + Irodori-TTS VoiceDesign")
 
         with gr.Tab("Chat"):
             chatbot = gr.Chatbot(label="Chat", height=400)
@@ -215,4 +242,5 @@ def build_ui():
 if __name__ == "__main__":
     demo = build_ui()
     demo.queue(default_concurrency_limit=1)
-    demo.launch(server_name="127.0.0.1", server_port=7860)
+    host = os.environ.get("GRADIO_SERVER_NAME", "127.0.0.1")
+    demo.launch(server_name=host, server_port=7860)


### PR DESCRIPTION
## Summary
- Apple Silicon (MLX) と NVIDIA GPU (CUDA) の両方で Bonsai-8B 1-bit + Irodori-TTS を動作可能に
- CUDA側は Docker Compose 必須（2サービス構成: llm + app）
- PrismML fork の llama.cpp をソースビルドし、1-bit Q1_0_g128 カーネルを CUDA で実行

## Performance (RTX 3090)
| 項目 | 値 |
|------|-----|
| LLM VRAM | 1.9 GB (1-bit) |
| TTS VRAM | 2.9 GB |
| 合計 VRAM | 4.8 GB |
| LLM応答 | 0.4s (180 tok/s) |
| TTS生成 | 1.6s |

## Test plan
- [x] RTX 3090 上で Docker Compose ビルド成功
- [x] チャット送信→LLM応答→TTS音声生成の一連フロー動作確認
- [x] `<think>` タグ除去の正常動作確認
- [x] VRAM使用量が1-bit相当（4.8GB）であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)