### PR TITLE
Add benchmark results: M5 vs RTX 3090

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local AI voice chat — [Bonsai-8B](https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit) (1-bit LLM) + [Irodori-TTS VoiceDesign](https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign) (Japanese TTS).
 
-Chat with "Midori", an AI assistant that talks back to you — entirely local, no cloud APIs needed. Runs on both Apple Silicon (MLX) and NVIDIA GPUs (CUDA via Docker).
+Chat with "Midori", an AI assistant that talks back to you — entirely local, no cloud APIs needed. Runs on both Apple Silicon (MLX) and NVIDIA GPUs (CUDA via Docker Compose).
 
 ## Features
 
@@ -21,8 +21,8 @@ Measured with 3 runs each, 15-step TTS, short Japanese prompts.
 | **LLM response** | 1.02s | 0.27s |
 | **TTS generation** (~4s audio) | 13.59s | 1.45s |
 | **Total per turn** | ~14.6s | ~1.7s |
-| **LLM VRAM** | ~1.4 GB | ~1.9 GB |
-| **TTS VRAM** | ~4 GB (shared) | ~2.9 GB |
+| **LLM memory** | ~1.4 GB (unified) | ~1.9 GB (VRAM) |
+| **TTS memory** | ~4 GB (unified) | ~2.9 GB (VRAM) |
 
 ## Requirements
 
@@ -100,7 +100,7 @@ User Input → Bonsai-8B (MLX, Apple GPU) → Response Text
 │  │ llm service │    │ app service        │  │
 │  │ (llama.cpp  │◄───│ (Gradio + TTS)     │  │
 │  │  1-bit CUDA)│    │ OpenAI API client  │  │
-│  │ :8080       │    │ :7860              │  │
+│  │ :8080       │    │ :7861 → :7860      │  │
 │  └─────────────┘    └────────────────────┘  │
 └─────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary
- Apple M5 (MLX/MPS) vs RTX 3090 (CUDA) ベンチマーク結果をREADMEに追加
- クロスプラットフォーム対応のセットアップ手順・アーキテクチャ図を更新

## Benchmark Results
| | Apple M5 | RTX 3090 |
|---|---|---|
| LLM | 1.02s | 0.27s |
| TTS (~4s audio) | 13.59s | 1.45s |

## Test plan
- [x] Mac MLX/MPS ベンチマーク 3回実行
- [x] CUDA RTX 3090 ベンチマーク 3回実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)